### PR TITLE
Force notifications to appear in foreground

### DIFF
--- a/src/growl.css
+++ b/src/growl.css
@@ -4,6 +4,7 @@
     right: 10px;
     float: right;
     width: 250px;
+    z-index: 9999;
 }
 
 .growl-item.ng-enter,


### PR DESCRIPTION
By default notifications appear behind boostrap navigation bar, nggrid table header etc. Setting the z-index of the growl class to a high value fixed the problem.
