### PR TITLE
Do not require an old angular version but anything >=1.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,9 +22,9 @@
 		".gitignore"
 	],
 	"dependencies": {
-		"angular": "1.2.1"
+		"angular": ">=1.2.0"
 	},
 	"devDependencies": {
-		"angular-mocks": "1.2.1"
+		"angular-mocks": ">=1.2.0"
 	}
 }


### PR DESCRIPTION
Whenever installing a new requirement via bower it is complaining about version conflicts. growl did a hard require on 1.2.1 which is not necessary at all 
