### PR TITLE
Add classes

### DIFF
--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -105,7 +105,7 @@ angular.module("angular-growl").provider("growl", function() {
 			var _config = config || {}, message;
 
 			message = {
-				classes: config.classes,
+				classes: _config.classes,
 				text: text,
 				severity: severity,
 				ttl: _config.ttl || _ttl,

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -105,6 +105,7 @@ angular.module("angular-growl").provider("growl", function() {
 			var _config = config || {}, message;
 
 			message = {
+				classes: config.classes,
 				text: text,
 				severity: severity,
 				ttl: _config.ttl || _ttl,


### PR DESCRIPTION
Allows users to add CSS classes to customize the notification. 

e.g. growl.addSuccessMessage('Message', {classes: 'blue-message exclamation-point'});
