### PR TITLE
add callback parameter to process message in calling angular app

### DIFF
--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -6,7 +6,8 @@ angular.module("angular-growl").provider("growl", function() {
 		_messagesKey = 'messages',
 		_messageTextKey = 'text',
 		_messageSeverityKey = 'severity',
-		_onlyUniqueMessages = true;
+		_onlyUniqueMessages = true,
+		_callback = null;
 
 	/**
 	 * set a global timeout (time to live) after which messages will be automatically closed
@@ -66,7 +67,7 @@ angular.module("angular-growl").provider("growl", function() {
 	 */
 	 this.registerCallback = function (callback) {
         _callback = callback;
-    }
+    };
 
 	/**
 	 * $http interceptor that can be added to array of $http interceptors during config phase of application

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -57,6 +57,16 @@ angular.module("angular-growl").provider("growl", function() {
 	this.onlyUniqueMessages = function(onlyUniqueMessages) {
 		_onlyUniqueMessages = onlyUniqueMessages;
 	};
+	
+	/**
+	 * defines a callback that would be called with the message object as parameter
+	 * this callback can be use to process the message in the angular app, e.g. write the message to a status bar
+	 * 
+	 * @param {function} callback default: null
+	 */
+	 this.registerCallback = function (callback) {
+        _callback = callback;
+    }
 
 	/**
 	 * $http interceptor that can be added to array of $http interceptors during config phase of application
@@ -112,6 +122,9 @@ angular.module("angular-growl").provider("growl", function() {
 			};
 
 			broadcastMessage(message);
+			if (_callback) {
+                  _callback(message);
+            }
 		}
 
 		/**


### PR DESCRIPTION
The callback can be use to process the message in the angular app, 

e.g. write the message to a status bar:

 growlProvider.registerCallback(function (message) {
        var html = "<div class='statusbar-" + message.severity+ "'>" + message.text + "</div>";
        $("#footerMsg").html(html);
    });
